### PR TITLE
Enable injecting a text value (to display)

### DIFF
--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -5,6 +5,7 @@ import { createEventDispatcher, onMount } from 'svelte'
 export let apiKey
 export let options = undefined
 export let placeholder = undefined
+export let value = ''
 
 const dispatch = createEventDispatcher()
 
@@ -87,4 +88,4 @@ function selectFirstSuggestion() {
 </script>
 
 <input bind:this={inputField} class={$$props.class} on:change={onChange}
-       on:keydown={onKeyDown} {placeholder} />
+       on:keydown={onKeyDown} {placeholder} {value} />


### PR DESCRIPTION
**Added:**
- Enable injecting a text value (to display)

---

This is to support use cases where the Svelte application using this component may need to show text in this GooglePlacesAutocomplete component in order to reflect a changed state within the Svelte application.

We intentionally did _not_ bind the value, merely let it be set. Data bubbles up out of this component through events, not through binding.