### PR TITLE
Fix enter-then-tab (and similar) use cases

### DIFF
--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -10,6 +10,7 @@ export let value = ''
 const dispatch = createEventDispatcher()
 
 let inputField
+let selectedLocation = null
 
 onMount(() => {
   loadGooglePlacesLibrary(apiKey, () => {
@@ -23,7 +24,7 @@ onMount(() => {
       // truly received location data from Google.
       // See the `Type something, no suggestions, hit Enter` test case.
       if (hasLocationData(place)) {
-        dispatch('place_changed', {
+        setSelectedLocation({
           place: place,
           text: inputField.value
         })
@@ -46,7 +47,7 @@ function hasLocationData(place) {
 
 function onChange() {
   if (inputField.value === '') {
-    dispatch('place_changed', null)
+    setSelectedLocation(null)
   }
 }
 
@@ -84,6 +85,11 @@ function selectFirstSuggestion() {
     { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 }
   )
   inputField.dispatchEvent(simulatedEvent)
+}
+
+function setSelectedLocation(data) {
+  selectedLocation = data
+  dispatch('place_changed', selectedLocation)
 }
 </script>
 

--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -60,7 +60,7 @@ function onKeyDown(event) {
       if (!isSuggestionSelected) {
         selectFirstSuggestion()
       }
-    } else {
+    } else if (doesNotMatchSelectedLocation(inputField.value)) {
       setTimeout(emptyLocationField, 10)
     }
   } else if (event.key === 'Escape') {
@@ -90,6 +90,11 @@ function selectFirstSuggestion() {
 function setSelectedLocation(data) {
   selectedLocation = data
   dispatch('place_changed', selectedLocation)
+}
+
+function doesNotMatchSelectedLocation(value) {
+  const selectedLocationText = (selectedLocation && selectedLocation.text) || null
+  return selectedLocationText !== value
 }
 </script>
 

--- a/test/TestApp.svelte
+++ b/test/TestApp.svelte
@@ -87,7 +87,7 @@ th {
   <tbody>
     {#each $tests as test (test.name) }
       <tr>
-        <td>{ test.name }</td>
+        <td class="{test.result || ''}">{ test.name }</td>
         <td>{ JSON.stringify(test.expected) }</td>
         <td class="uppercase {test.result || ''}">{ test.result || '' }</td>
         <td>{ test.details || '' }</td>

--- a/test/TestApp.svelte
+++ b/test/TestApp.svelte
@@ -2,7 +2,7 @@
 import GooglePlacesAutocomplete from '../src/GooglePlacesAutocomplete.svelte'
 import { displayText, displayTextCssClass, showText } from './helpers/instructions'
 import { locationInput, onPlaceChanged } from './helpers/interactions'
-import { runTests } from './helpers/running'
+import { running, runTests } from './helpers/running'
 import tests from './tests'
 
 const options = {
@@ -97,5 +97,5 @@ th {
 </table>
 
 {#if googlePlacesApiKey}
-  <button on:click={runTests}>Re-run tests</button>
+  <button on:click={runTests} disabled={$running}>Re-run tests</button>
 {/if}

--- a/test/TestApp.svelte
+++ b/test/TestApp.svelte
@@ -1,7 +1,7 @@
 <script>
 import GooglePlacesAutocomplete from '../src/GooglePlacesAutocomplete.svelte'
 import { displayText, displayTextCssClass, showText } from './helpers/instructions'
-import { locationInput, onPlaceChanged } from './helpers/interactions'
+import { checkTestResult, locationInput, resultingLocation } from './helpers/interactions'
 import { running, runTests } from './helpers/running'
 import tests from './tests'
 
@@ -25,6 +25,11 @@ showText('Please enter your Google Places API Key', 'command')
 function onApiKeyProvided(event) {
   googlePlacesApiKey = event.target.value
   showText('Loading Google Places API...')
+}
+
+function onPlaceChanged(event) {
+  $resultingLocation = event.detail
+  checkTestResult()
 }
 </script>
 

--- a/test/helpers/interactions.js
+++ b/test/helpers/interactions.js
@@ -1,13 +1,37 @@
-import { writable } from 'svelte/store'
+import { get, writable } from 'svelte/store'
+import { waitAMoment } from "./waiting";
 
 export const locationInput = new writable(null)
+export const resultingLocation = new writable(null)
 
-let onPlaceChangeCallback = Function()
+let onTestDoneCallback = Function()
 
-export function onPlaceChanged(event) {
-  onPlaceChangeCallback(event.detail)
+export function checkTestResult() {
+  const resultingLocationName = getResultingLocationName()
+  onTestDoneCallback(resultingLocationName)
 }
 
-export function whenPlaceChanges(callback) {
-  onPlaceChangeCallback = callback
+/**
+ * After waiting long enough for any place_changed events to have fired, check
+ * the result of the test.
+ *
+ * @returns {Promise<void>}
+ */
+export async function checkTestResultAfterAMoment() {
+  return waitAMoment(1000).then(() => checkTestResult())
+}
+
+/**
+ * Get the name of the resulting location (if any) selected by the user's
+ * actions. If no location is currently selected, returns an empty string.
+ * 
+ * @returns {string}
+ */
+export function getResultingLocationName() {
+  const resultingLocationData = get(resultingLocation) || {}
+  return resultingLocationData.text || ''
+}
+
+export function whenDone(callback) {
+  onTestDoneCallback = callback
 }

--- a/test/helpers/interactions.js
+++ b/test/helpers/interactions.js
@@ -2,14 +2,12 @@ import { writable } from 'svelte/store'
 
 export const locationInput = new writable(null)
 
-const onPlaceChangeCallbacks = []
+let onPlaceChangeCallback = Function()
 
 export function onPlaceChanged(event) {
-  while (onPlaceChangeCallbacks.length) {
-    onPlaceChangeCallbacks.pop()(event.detail)
-  }
+  onPlaceChangeCallback(event.detail)
 }
 
 export function whenPlaceChanges(callback) {
-  onPlaceChangeCallbacks.push(callback)
+  onPlaceChangeCallback = callback
 }

--- a/test/helpers/running.js
+++ b/test/helpers/running.js
@@ -1,5 +1,5 @@
 import { clearText, showText } from './instructions'
-import { locationInput, whenPlaceChanges } from './interactions'
+import { locationInput, resultingLocation, whenDone } from './interactions'
 import { get, writable } from 'svelte/store'
 import tests from '../tests'
 import { waitAMoment } from './waiting'
@@ -65,16 +65,15 @@ async function runTest(test) {
     // regarding the final location value returned.
     await waitAMoment(1000)
     
-    whenPlaceChanges(location => {
+    whenDone(resultingLocationName => {
       clearText()
       clearTimeout(timeoutHandle)
-      const actualResult = (location && location.text) || ''
-      if (actualResult === test.expected) {
+      if (resultingLocationName === test.expected) {
         resolve()
       } else {
         reject(
           `Expected ${JSON.stringify(test.expected)} ` +
-          `but found ${JSON.stringify(actualResult)}`
+          `but found ${JSON.stringify(resultingLocationName)}`
         )
       }
     })
@@ -86,4 +85,6 @@ async function runTest(test) {
 
 function resetForNextTest() {
   get(locationInput).value = ''
+  resultingLocation.set(null)
+  whenDone(Function())
 }

--- a/test/helpers/running.js
+++ b/test/helpers/running.js
@@ -60,10 +60,10 @@ async function runTest(test) {
     resetForNextTest()
     await test.setup()
     
-    whenPlaceChanges(() => {
+    whenPlaceChanges(location => {
       clearText()
       clearTimeout(timeoutHandle)
-      const actualResult = get(locationInput).value
+      const actualResult = (location && location.text) || ''
       if (actualResult === test.expected) {
         resolve()
       } else {

--- a/test/helpers/running.js
+++ b/test/helpers/running.js
@@ -1,8 +1,10 @@
 import { clearText, showText } from './instructions'
 import { locationInput, whenPlaceChanges } from './interactions'
-import { get } from 'svelte/store'
+import { get, writable } from 'svelte/store'
 import tests from '../tests'
 import { waitAMoment } from './waiting'
+
+export const running = new writable(false)
 
 export function resetTestResults() {
   const copyOfTests = get(tests)
@@ -14,6 +16,8 @@ export function resetTestResults() {
 }
 
 export async function runTests() {
+  running.set(true)
+  
   locationInput.set(document.querySelector('input'))
   get(locationInput).focus()
   
@@ -43,6 +47,8 @@ export async function runTests() {
   } else {
     showText('All tests passed', 'pass')
   }
+  
+  running.set(false)
 }
 
 async function runTest(test) {

--- a/test/helpers/running.js
+++ b/test/helpers/running.js
@@ -60,6 +60,11 @@ async function runTest(test) {
     resetForNextTest()
     await test.setup()
     
+    // Ensure any `place_changed` events that Google will fire in response to
+    // our test setup have already passed, so that we will get accurate results
+    // regarding the final location value returned.
+    await waitAMoment(1000)
+    
     whenPlaceChanges(location => {
       clearText()
       clearTimeout(timeoutHandle)

--- a/test/helpers/typing.js
+++ b/test/helpers/typing.js
@@ -5,6 +5,7 @@ import { waitAMoment } from './waiting'
 
 export async function type(letters) {
   showText('Please wait')
+  get(locationInput).value = ''
   for (let i = 0; i < letters.length; i++) {
     await typeLetter(letters[i])
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -36,6 +36,18 @@ export default writable([
     expected: 'Atlanta, GA, USA',
   },
   {
+    name: `Type something, see suggestions, don't select any, hit Enter, hit Enter`,
+    setup: async () => {
+      await type('new')
+      await waitForSuggestions()
+      return hitKey('Enter', 0, 13)
+    },
+    
+    // Since this test shouldn't trigger a place_changed event, explicitly check the results.
+    go: () => hitKey('Enter', 0, 13).then(checkTestResultAfterAMoment),
+    expected: 'New York, NY, USA',
+  },
+  {
     name: `Type something, see suggestions, select one via Arrow keys, hit Enter`,
     setup: async () => {
       await type('atl')

--- a/test/tests.js
+++ b/test/tests.js
@@ -24,6 +24,16 @@ export default writable([
     expected: 'New York, NY, USA',
   },
   {
+    name: `Type something, see suggestions, don't select any, hit Enter, hit Tab`,
+    setup: async () => {
+      await type('atl')
+      await waitForSuggestions()
+      return hitKey('Enter', 0, 13)
+    },
+    go: () => hitKey('Tab', 0, 9),
+    expected: 'Atlanta, GA, USA',
+  },
+  {
     name: `Type something, see suggestions, select one via Arrow keys, hit Enter`,
     setup: async () => {
       await type('atl')

--- a/test/tests.js
+++ b/test/tests.js
@@ -48,6 +48,32 @@ export default writable([
     expected: 'New York, NY, USA',
   },
   {
+    name: `Type something, see suggestions, don't select any, hit Enter, ` +
+          `type something else, see no suggestions, hit Tab`,
+    setup: async () => {
+      await type('atl')
+      await waitForSuggestions()
+      await hitKey('Enter', 0, 13)
+      await type('zzzzzzz')
+      return waitAMoment()
+    },
+    go: () => hitKey('Tab', 0, 9),
+    expected: '',
+  },
+  {
+    name: `Type something, see suggestions, don't select any, hit Enter, ` +
+          `type something else, see no suggestions, hit Enter`,
+    setup: async () => {
+      await type('new')
+      await waitForSuggestions()
+      await hitKey('Enter', 0, 13)
+      await type('zzzzzzzz')
+      return waitAMoment()
+    },
+    go: () => hitKey('Enter', 0, 13),
+    expected: '',
+  },
+  {
     name: `Type something, see suggestions, select one via Arrow keys, hit Enter`,
     setup: async () => {
       await type('atl')

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,7 +1,7 @@
 import { showText } from "./helpers/instructions"
-import { locationInput } from './helpers/interactions'
+import { checkTestResultAfterAMoment, locationInput } from './helpers/interactions'
 import { hitKey, type } from './helpers/typing'
-import { waitForSuggestions } from './helpers/waiting'
+import { waitAMoment, waitForSuggestions } from './helpers/waiting'
 import { get, writable } from 'svelte/store'
 
 export default writable([
@@ -30,7 +30,9 @@ export default writable([
       await waitForSuggestions()
       return hitKey('Enter', 0, 13)
     },
-    go: () => hitKey('Tab', 0, 9),
+    
+    // Since this test shouldn't trigger a place_changed event, explicitly check the results.
+    go: () => hitKey('Tab', 0, 9).then(checkTestResultAfterAMoment),
     expected: 'Atlanta, GA, USA',
   },
   {


### PR DESCRIPTION
**Fixed:**
- Hitting Tab or Enter (after having selected a suggestion) no longer empties the field.

---

@wcjr - Please feel free to give any feedback whatsoever on this one. I got it working, but I feel like I left the code (especially the test code) in a slightly less readable condition. 