### PR TITLE
fixes hasLocationData when options.fields is 'ALL'

### DIFF
--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -43,7 +43,7 @@ function emptyLocationField() {
 }
 
 function hasLocationData(place) {
-  const fieldsToLookFor = (options && options.fields) || ['geometry']
+  const fieldsToLookFor = (options && options.fields && options.fields.indexOf('ALL') === -1) || ['geometry']
   return place.hasOwnProperty(fieldsToLookFor[0])
 }
 

--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -43,7 +43,7 @@ function emptyLocationField() {
 }
 
 function hasLocationData(place) {
-  const fieldsToLookFor = (options && options.fields && options.fields.indexOf('ALL') === -1) || ['geometry']
+  const fieldsToLookFor = (options && options.fields?.indexOf('ALL') === -1 && options.fields) || ['geometry']
   return place.hasOwnProperty(fieldsToLookFor[0])
 }
 


### PR DESCRIPTION
As per [the api documentation](https://developers.google.com/maps/documentation/javascript/place-autocomplete#add-autocomplete) fields can be `['ALL']`. 

Not that it should be used in production as billing increases but should be supported nonetheless.