### PR TITLE
Release 1.2.2 - Fix lack of `callback` when loading Google Maps JavaScript API

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,4 +20,10 @@
 
 ### Release PR Checklist
 - [ ] Update version number in package.json
-- [ ] After merge, publish to npmjs.com
+- [ ] Run `make install` to update version number in package-lock.json
+- [ ] Make sure everything looks good in a DRY RUN of publishing this to npm: `npm publish --dry-run`
+
+After merge...
+- [ ] Tag that commit on `master`
+- [ ] Check out that commit
+- [ ] Publish that version to NPM: `npm publish --access public`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+### Added
+- 
+
+### Changed
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+- 
+
+### Security
+-
+
+---
+
+### Release PR Checklist
+- [ ] Update version number in package.json
+- [ ] After merge, publish to npmjs.com

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 /dist/
 test/test-bundle.*
+.idea/

--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ and this component is therefore ready for user interaction.
 ### Modifying the tests
 
 The tests are defined in `test/tests.js`. See that file for examples.
+
+## Install with [npm](https://www.npmjs.com/package/@silintl/svelte-google-places-autocomplete)
+
+    $ npm install @silintl/svelte-google-places-autocomplete

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silintl/svelte-google-places-autocomplete",
-  "version": "1.1.6",
+  "version": "1.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@silintl/svelte-google-places-autocomplete",
-      "version": "1.1.6",
+      "version": "1.2.2",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silintl/svelte-google-places-autocomplete",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "description": "A minimal port of the [Google Places Autocomplete API](https://developers.google.com/maps/documentation/javascript/places-autocomplete) as a Svelte component.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Fixed
- Fix error: "Loading the Google Maps JavaScript API without a callback is not supported"

---

### Release PR Checklist
- [x] Update version number in package.json
- [x] Run `make install` to update version number in package-lock.json
- [x] Make sure everything looks good in a DRY RUN of publishing this to npm: `npm publish --dry-run`

After merge...
- [ ] Tag that commit on `master`
- [ ] Check out that commit
- [ ] Publish that version to NPM: `npm publish --access public`

---

This will fix #24.