### PR TITLE
Fix for default pattern attribute value

### DIFF
--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -7,7 +7,7 @@ export let options = undefined
 export let placeholder = undefined
 export let value = ''
 export let required = false;
-export let pattern = '';
+export let pattern = undefined;
 
 const dispatch = createEventDispatcher()
 
@@ -17,10 +17,10 @@ $: selectedLocationName = value || ''
 onMount(() => {
   loadGooglePlacesLibrary(apiKey, () => {
     const autocomplete = new google.maps.places.Autocomplete(inputField, options)
-    
+
     autocomplete.addListener('place_changed', () => {
       const place = autocomplete.getPlace()
-      
+
       // There are circumstances where the place_changed event fires, but we
       // were NOT given location data. I only want to propagate the event if we
       // truly received location data from Google.
@@ -32,7 +32,7 @@ onMount(() => {
         })
       }
     })
-    
+
     dispatch('ready')
   })
 })
@@ -55,7 +55,7 @@ function onChange() {
 
 function onKeyDown(event) {
   const suggestionsAreVisible = document.getElementsByClassName('pac-item').length
-  
+
   if (event.key === 'Enter' || event.key === 'Tab') {
     if (suggestionsAreVisible) {
       const isSuggestionSelected = document.getElementsByClassName('pac-item-selected').length
@@ -68,7 +68,7 @@ function onKeyDown(event) {
   } else if (event.key === 'Escape') {
     setTimeout(emptyLocationField, 10)
   }
-  
+
   if (suggestionsAreVisible) {
     if (event.key === 'Enter') {
       /* When suggestions are visible, don't let an 'Enter' submit a form (since

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,7 +7,7 @@ import { get, writable } from 'svelte/store'
 export default writable([
   {
     name: `Type something, see suggestions, click on one`,
-    setup: async () => await type('new').then(waitForSuggestions),
+    setup: async () => await type('new york').then(waitForSuggestions),
     go: () => showText('Please click on the first suggestion', 'command'),
     expected: 'New York, NY, USA',
   },
@@ -19,7 +19,7 @@ export default writable([
   },
   {
     name: `Type something, see suggestions, don't select any, hit Tab`,
-    setup: async () => await type('new').then(waitForSuggestions),
+    setup: async () => await type('new york').then(waitForSuggestions),
     go: () => hitKey('Tab', 0, 9),
     expected: 'New York, NY, USA',
   },
@@ -30,7 +30,6 @@ export default writable([
       await waitForSuggestions()
       return hitKey('Enter', 0, 13)
     },
-    
     // Since this test shouldn't trigger a place_changed event, explicitly check the results.
     go: () => hitKey('Tab', 0, 9).then(checkTestResultAfterAMoment),
     expected: 'Atlanta, GA, USA',
@@ -38,11 +37,10 @@ export default writable([
   {
     name: `Type something, see suggestions, don't select any, hit Enter, hit Enter`,
     setup: async () => {
-      await type('new')
+      await type('new york')
       await waitForSuggestions()
       return hitKey('Enter', 0, 13)
     },
-    
     // Since this test shouldn't trigger a place_changed event, explicitly check the results.
     go: () => hitKey('Enter', 0, 13).then(checkTestResultAfterAMoment),
     expected: 'New York, NY, USA',
@@ -64,7 +62,7 @@ export default writable([
     name: `Type something, see suggestions, don't select any, hit Enter, ` +
           `type something else, see no suggestions, hit Enter`,
     setup: async () => {
-      await type('new')
+      await type('new york')
       await waitForSuggestions()
       await hitKey('Enter', 0, 13)
       await type('zzzzzzzz')
@@ -86,7 +84,7 @@ export default writable([
   {
     name: `Type something, see suggestions, select one via Arrow keys, hit Tab`,
     setup: async () => {
-      await type('new')
+      await type('new york')
       await waitForSuggestions()
       return hitKey('ArrowDown', 0, 40)
     },
@@ -114,7 +112,6 @@ export default writable([
   {
     name: `Pass in a value`,
     setup: async () => passInValue('Atlanta, GA, USA'),
-    
     // Since this test shouldn't trigger a place_changed event, explicitly check the results.
     go: () => checkTestResultAfterAMoment(),
     expected: 'Atlanta, GA, USA',


### PR DESCRIPTION
### Fixed
- `pattern` attribute should be undefined by default. Fixes #34
- Update test query from "new" to "new york" to fix failing tests

---

### Release PR Checklist
- [ ] Update version number in package.json
- [ ] Run `make install` to update version number in package-lock.json
- [ ] Make sure everything looks good in a DRY RUN of publishing this to npm: `npm publish --dry-run`

After merge...
- [ ] Tag that commit on `master`
- [ ] Check out that commit
- [ ] Publish that version to NPM: `npm publish --access public`