### PR TITLE
fix missing exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
   },
   "homepage": "https://github.com/silinternational/svelte-google-places-autocomplete#readme",
   "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "src/index.js"
+    }
+  },
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### Fixed
-  Using the svelte field in package.json to point at .svelte source files is deprecated and you must use a svelte [export condition](https://nodejs.org/api/packages.html#conditional-exports). vite-plugin-svelte 3 still resolves it as a fallback, but in a future major release this is going to be removed and without exports condition resolving the library is going to fail.
see: https://github.com/silinternational/svelte-google-places-autocomplete/issues/36
