### PR TITLE
Release 1.2.3

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+# Ignore artifacts:
+dist
+
+# Ignore build dependencies
+node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "printWidth": 120,
+  "semi": false,
+  "tabWidth": 2,
+  "singleQuote": true,
+  "useTabs": false,
+
+  "svelteAllowShorthand": true,
+  "svelteIndentScriptAndStyle": false
+}

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ test: build
 clean:
 	npm prune
 	npm run clean
+
+format:
+	npm run format

--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@ The tests are defined in `test/tests.js`. See that file for examples.
 ## Install with [npm](https://www.npmjs.com/package/@silintl/svelte-google-places-autocomplete)
 
     $ npm install @silintl/svelte-google-places-autocomplete
+
+## Contributing
+
+Please use the included prettier config for formatting. You can also run `make format` to format all files with prettier.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^6.0.0",
         "npm-run-all": "^4.1.5",
+        "prettier": "^2",
+        "prettier-plugin-svelte": "^2",
         "rollup": "^1.32.1",
         "rollup-plugin-livereload": "^1.3.0",
         "rollup-plugin-svelte": "^6.1.1",
@@ -1005,6 +1007,31 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-svelte": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.10.1.tgz",
+      "integrity": "sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==",
+      "dev": true,
+      "peerDependencies": {
+        "prettier": "^1.16.4 || ^2.0.0",
+        "svelte": "^3.2.0 || ^4.0.0-next.0"
       }
     },
     "node_modules/read-pkg": {
@@ -2128,6 +2155,19 @@
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
+    },
+    "prettier": {
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "dev": true
+    },
+    "prettier-plugin-svelte": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-svelte/-/prettier-plugin-svelte-2.10.1.tgz",
+      "integrity": "sha512-Wlq7Z5v2ueCubWo0TZzKc9XHcm7TDxqcuzRuGd0gcENfzfT4JZ9yDlCbEgxWgiPmLHkBjfOtpAWkcT28MCDpUQ==",
+      "dev": true,
+      "requires": {}
     },
     "read-pkg": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silintl/svelte-google-places-autocomplete",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@silintl/svelte-google-places-autocomplete",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silintl/svelte-google-places-autocomplete",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A minimal port of the [Google Places Autocomplete API](https://developers.google.com/maps/documentation/javascript/places-autocomplete) as a Svelte component.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,11 @@
   },
   "homepage": "https://github.com/silinternational/svelte-google-places-autocomplete#readme",
   "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "src/index.js"
+    }
+  },
   "module": "dist/index.mjs",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,14 @@
     "build": "rollup -c",
     "prepublishOnly": "npm run build",
     "sirvTest": "sirv test --port 8086 --single --dev",
-    "test": "run-p autobuild autobuildTest sirvTest"
+    "test": "run-p autobuild autobuildTest sirvTest",
+    "format": "prettier --write ./src/*.{js,svelte}"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^6.0.0",
     "npm-run-all": "^4.1.5",
+    "prettier": "^2",
+    "prettier-plugin-svelte": "^2",
     "rollup": "^1.32.1",
     "rollup-plugin-livereload": "^1.3.0",
     "rollup-plugin-svelte": "^6.1.1",

--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -7,7 +7,7 @@ export let options = undefined
 export let placeholder = undefined
 export let value = ''
 export let required = false;
-export let pattern = '';
+export let pattern = undefined;
 
 const dispatch = createEventDispatcher()
 
@@ -17,10 +17,10 @@ $: selectedLocationName = value || ''
 onMount(() => {
   loadGooglePlacesLibrary(apiKey, () => {
     const autocomplete = new google.maps.places.Autocomplete(inputField, options)
-    
+
     autocomplete.addListener('place_changed', () => {
       const place = autocomplete.getPlace()
-      
+
       // There are circumstances where the place_changed event fires, but we
       // were NOT given location data. I only want to propagate the event if we
       // truly received location data from Google.
@@ -32,7 +32,7 @@ onMount(() => {
         })
       }
     })
-    
+
     dispatch('ready')
   })
 })
@@ -55,7 +55,7 @@ function onChange() {
 
 function onKeyDown(event) {
   const suggestionsAreVisible = document.getElementsByClassName('pac-item').length
-  
+
   if (event.key === 'Enter' || event.key === 'Tab') {
     if (suggestionsAreVisible) {
       const isSuggestionSelected = document.getElementsByClassName('pac-item-selected').length
@@ -68,7 +68,7 @@ function onKeyDown(event) {
   } else if (event.key === 'Escape') {
     setTimeout(emptyLocationField, 10)
   }
-  
+
   if (suggestionsAreVisible) {
     if (event.key === 'Enter') {
       /* When suggestions are visible, don't let an 'Enter' submit a form (since

--- a/src/GooglePlacesAutocomplete.svelte
+++ b/src/GooglePlacesAutocomplete.svelte
@@ -6,8 +6,8 @@ export let apiKey
 export let options = undefined
 export let placeholder = undefined
 export let value = ''
-export let required = false;
-export let pattern = undefined;
+export let required = false
+export let pattern = undefined
 
 const dispatch = createEventDispatcher()
 
@@ -28,7 +28,7 @@ onMount(() => {
       if (hasLocationData(place)) {
         setSelectedLocation({
           place: place,
-          text: inputField.value
+          text: inputField.value,
         })
       }
     })
@@ -82,10 +82,7 @@ function onKeyDown(event) {
 function selectFirstSuggestion() {
   // Simulate the 'down arrow' key in order to select the first suggestion:
   // https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events
-  const simulatedEvent = new KeyboardEvent(
-    'keydown',
-    { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 }
-  )
+  const simulatedEvent = new KeyboardEvent('keydown', { key: 'ArrowDown', code: 'ArrowDown', keyCode: 40 })
   inputField.dispatchEvent(simulatedEvent)
 }
 
@@ -99,5 +96,13 @@ function doesNotMatchSelectedLocation(value) {
 }
 </script>
 
-<input bind:this={inputField} class={$$props.class} on:change={onChange}
-       on:keydown={onKeyDown} {placeholder} {value} {required} {pattern}/>
+<input
+  bind:this={inputField}
+  class={$$props.class}
+  on:change={onChange}
+  on:keydown={onKeyDown}
+  {placeholder}
+  {value}
+  {required}
+  {pattern}
+/>

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-export { default as default } from './GooglePlacesAutocomplete.svelte';
+export { default as default } from './GooglePlacesAutocomplete.svelte'

--- a/src/loader.js
+++ b/src/loader.js
@@ -31,20 +31,22 @@ export function loadGooglePlacesLibrary(apiKey, callback) {
     callback()
     return
   }
-  
+
   callback && callbacks.push(callback)
-  
+
   if (isLoadingLibrary) {
     return
   }
-  
+
   isLoadingLibrary = true
-  
+
   const element = document.createElement('script')
   element.async = true
   element.defer = true
   element.onload = onLibraryLoaded
-  element.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(apiKey)}&libraries=places&callback=Function.prototype`
+  element.src = `https://maps.googleapis.com/maps/api/js?key=${encodeURIComponent(
+    apiKey
+  )}&libraries=places&callback=Function.prototype`
   element.type = 'text/javascript'
 
   document.head.appendChild(element)
@@ -53,7 +55,7 @@ export function loadGooglePlacesLibrary(apiKey, callback) {
 function onLibraryLoaded() {
   isLoadingLibrary = false
   let callback
-  while (callback = callbacks.pop()) {
+  while ((callback = callbacks.pop())) {
     callback()
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -7,7 +7,7 @@ import { get, writable } from 'svelte/store'
 export default writable([
   {
     name: `Type something, see suggestions, click on one`,
-    setup: async () => await type('new').then(waitForSuggestions),
+    setup: async () => await type('new york').then(waitForSuggestions),
     go: () => showText('Please click on the first suggestion', 'command'),
     expected: 'New York, NY, USA',
   },
@@ -19,7 +19,7 @@ export default writable([
   },
   {
     name: `Type something, see suggestions, don't select any, hit Tab`,
-    setup: async () => await type('new').then(waitForSuggestions),
+    setup: async () => await type('new york').then(waitForSuggestions),
     go: () => hitKey('Tab', 0, 9),
     expected: 'New York, NY, USA',
   },
@@ -30,7 +30,6 @@ export default writable([
       await waitForSuggestions()
       return hitKey('Enter', 0, 13)
     },
-    
     // Since this test shouldn't trigger a place_changed event, explicitly check the results.
     go: () => hitKey('Tab', 0, 9).then(checkTestResultAfterAMoment),
     expected: 'Atlanta, GA, USA',
@@ -38,11 +37,10 @@ export default writable([
   {
     name: `Type something, see suggestions, don't select any, hit Enter, hit Enter`,
     setup: async () => {
-      await type('new')
+      await type('new york')
       await waitForSuggestions()
       return hitKey('Enter', 0, 13)
     },
-    
     // Since this test shouldn't trigger a place_changed event, explicitly check the results.
     go: () => hitKey('Enter', 0, 13).then(checkTestResultAfterAMoment),
     expected: 'New York, NY, USA',
@@ -64,7 +62,7 @@ export default writable([
     name: `Type something, see suggestions, don't select any, hit Enter, ` +
           `type something else, see no suggestions, hit Enter`,
     setup: async () => {
-      await type('new')
+      await type('new york')
       await waitForSuggestions()
       await hitKey('Enter', 0, 13)
       await type('zzzzzzzz')
@@ -86,7 +84,7 @@ export default writable([
   {
     name: `Type something, see suggestions, select one via Arrow keys, hit Tab`,
     setup: async () => {
-      await type('new')
+      await type('new york')
       await waitForSuggestions()
       return hitKey('ArrowDown', 0, 40)
     },
@@ -114,7 +112,6 @@ export default writable([
   {
     name: `Pass in a value`,
     setup: async () => passInValue('Atlanta, GA, USA'),
-    
     // Since this test shouldn't trigger a place_changed event, explicitly check the results.
     go: () => checkTestResultAfterAMoment(),
     expected: 'Atlanta, GA, USA',


### PR DESCRIPTION
### Add
- Added prettier

### Fixed
- fix missing exports
- [make pattern attr undefined by default](https://github.com/silinternational/svelte-google-places-autocomplete/commit/b8b313e569a39149fde6a82c4224a50dfd5a6f44)

---

### Release PR Checklist
- [x] Update version number in package.json
- [x] Run `make install` to update version number in package-lock.json
- [x] Make sure everything looks good in a DRY RUN of publishing this to npm: `npm publish --dry-run`

After merge...
- [ ] Tag that commit on `master`
- [ ] Check out that commit
- [ ] Publish that version to NPM: `npm publish --access public`