### PR TITLE
Archiving: Add "no longer maintained" warning to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# WARNING: This repo is no longer maintained
+
 # svelte-google-places-autocomplete
 
 A minimal port of the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silintl/svelte-google-places-autocomplete",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@silintl/svelte-google-places-autocomplete",
-      "version": "1.2.5",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silintl/svelte-google-places-autocomplete",
-  "version": "1.2.5",
+  "version": "1.3.0",
   "description": "A minimal port of the [Google Places Autocomplete API](https://developers.google.com/maps/documentation/javascript/places-autocomplete) as a Svelte component.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Deprecated
- Add "no longer maintained" warning to README.md

---

### Release PR Checklist
- [x] Update version number in package.json
- [x] Run `make install` to update version number in package-lock.json
- [x] Make sure everything looks good in a DRY RUN of publishing this to npm: `npm publish --dry-run`

After merge...
- [x] Tag that commit on `master`
- [x] Check out that commit
- [x] Publish that version to NPM: `npm publish --access public`